### PR TITLE
RP-Initiated Logout phase

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -20,7 +20,8 @@ module OmniAuth
         authorization_endpoint: '/authorize',
         token_endpoint: '/token',
         userinfo_endpoint: '/userinfo',
-        jwks_uri: '/jwk'
+        jwks_uri: '/jwk',
+        end_session_endpoint: nil
       }
       option :issuer
       option :discovery, false
@@ -42,6 +43,7 @@ module OmniAuth
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
+      option :post_logout_redirect_uri
 
       uid { user_info.sub }
 
@@ -82,8 +84,7 @@ module OmniAuth
       end
 
       def request_phase
-        options.issuer = issuer if options.issuer.blank?
-        discover! if options.discovery
+        discover!
         redirect authorize_uri
       end
 
@@ -96,8 +97,7 @@ module OmniAuth
         elsif !request.params['code']
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
         else
-          options.issuer = issuer if options.issuer.blank?
-          discover! if options.discovery
+          discover!
           client.redirect_uri = redirect_uri
           client.authorization_code = authorization_code
           access_token
@@ -111,8 +111,24 @@ module OmniAuth
         fail!(:failed_to_connect, e)
       end
 
+      def other_phase
+        discover!
+        if logout_path_pattern.match(current_path) && end_session_uri
+          redirect end_session_uri
+        else
+          call_app!
+        end
+      end
+
       def authorization_code
         request.params['code']
+      end
+
+      def end_session_uri
+        return unless end_session_endpoint_is_valid?
+        end_session_uri = URI(client_options.end_session_endpoint)
+        end_session_uri.query = encoded_post_logout_redirect_uri
+        end_session_uri.to_s
       end
 
       def authorize_uri
@@ -143,10 +159,17 @@ module OmniAuth
       end
 
       def discover!
-        client_options.authorization_endpoint = config.authorization_endpoint
-        client_options.token_endpoint = config.token_endpoint
-        client_options.userinfo_endpoint = config.userinfo_endpoint
-        client_options.jwks_uri = config.jwks_uri
+        return unless options.discovery
+        options.issuer = issuer if options.issuer.blank?
+        setup_client_options(config)
+      end
+
+      def setup_client_options(discover)
+        client_options.authorization_endpoint = discover.authorization_endpoint
+        client_options.token_endpoint = discover.token_endpoint
+        client_options.userinfo_endpoint = discover.userinfo_endpoint
+        client_options.jwks_uri = discover.jwks_uri
+        client_options.end_session_endpoint = discover.try :end_session_endpoint
       end
 
       def user_info
@@ -233,6 +256,22 @@ module OmniAuth
       def redirect_uri
         return client_options.redirect_uri unless request.params['redirect_uri']
         "#{ client_options.redirect_uri }?redirect_uri=#{ CGI.escape(request.params['redirect_uri']) }"
+      end
+
+      def encoded_post_logout_redirect_uri
+        return unless options.post_logout_redirect_uri
+        URI.encode_www_form(
+          post_logout_redirect_uri: options.post_logout_redirect_uri
+        )
+      end
+
+      def end_session_endpoint_is_valid?
+        client_options.end_session_endpoint &&
+          client_options.end_session_endpoint =~ URI::DEFAULT_PARSER.make_regexp
+      end
+
+      def logout_path_pattern
+        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}(/logout)}
       end
 
       class CallbackError < StandardError

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -112,12 +112,11 @@ module OmniAuth
       end
 
       def other_phase
-        discover!
-        if logout_path_pattern.match(current_path) && end_session_uri
-          redirect end_session_uri
-        else
-          call_app!
+        if logout_path_pattern.match(current_path)
+          discover!
+          return redirect(end_session_uri) if end_session_uri
         end
+        call_app!
       end
 
       def authorization_code

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -84,6 +84,7 @@ module OmniAuth
       end
 
       def request_phase
+        options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
         discover!
         redirect authorize_uri
       end
@@ -97,6 +98,7 @@ module OmniAuth
         elsif !request.params['code']
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
         else
+          options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
           discover!
           client.redirect_uri = redirect_uri
           client.authorization_code = authorization_code
@@ -112,7 +114,8 @@ module OmniAuth
       end
 
       def other_phase
-        if logout_path_pattern.match(current_path)
+        if logout_path_pattern.match?(current_path)
+          options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
           discover!
           return redirect(end_session_uri) if end_session_uri
         end
@@ -159,16 +162,11 @@ module OmniAuth
 
       def discover!
         return unless options.discovery
-        options.issuer = issuer if options.issuer.blank?
-        setup_client_options(config)
-      end
-
-      def setup_client_options(discover)
-        client_options.authorization_endpoint = discover.authorization_endpoint
-        client_options.token_endpoint = discover.token_endpoint
-        client_options.userinfo_endpoint = discover.userinfo_endpoint
-        client_options.jwks_uri = discover.jwks_uri
-        client_options.end_session_endpoint = discover.try :end_session_endpoint
+        client_options.authorization_endpoint = config.authorization_endpoint
+        client_options.token_endpoint = config.token_endpoint
+        client_options.userinfo_endpoint = config.userinfo_endpoint
+        client_options.jwks_uri = config.jwks_uri
+        client_options.end_session_endpoint = config.end_session_endpoint if config.respond_to?(:end_session_endpoint)
       end
 
       def user_info


### PR DESCRIPTION
Hello,

Here is an implementation of the logout phase initiated by the RP.

The relative spec:
[http://openid.net/specs/openid-connect-session-1_0.html#RPLogout](http://openid.net/specs/openid-connect-session-1_0.html#RPLogout)

I've also updated `openid_connect` dependency to 1.1.6 which supports `end_session_endpoint` in discovery response.

For information I already use a fork of `omniauth_openid_connect` with `openid_connect` 1.1.6 on a rails app in production.