### PR TITLE
Allows ui_locales, claims_locales and login_hint as request params

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -37,7 +37,6 @@ module OmniAuth
       option :max_age
       option :ui_locales
       option :id_token_hint
-      option :login_hint
       option :acr_values
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
@@ -121,7 +120,9 @@ module OmniAuth
           response_type: options.response_type,
           scope: options.scope,
           state: new_state,
-          login_hint: options.login_hint,
+          login_hint: params['login_hint'],
+          ui_locales: params['ui_locales'],
+          claims_locales: params['claims_locales'],
           prompt: options.prompt,
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
@@ -233,6 +234,10 @@ module OmniAuth
       def redirect_uri
         return client_options.redirect_uri unless request.params['redirect_uri']
         "#{ client_options.redirect_uri }?redirect_uri=#{ CGI.escape(request.params['redirect_uri']) }"
+      end
+
+      def params
+        request.params
       end
 
       class CallbackError < StandardError

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -18,6 +18,16 @@ module OmniAuth
         strategy.request_phase
       end
 
+      def test_request_phase_with_params
+        expected_redirect = /^https:\/\/example\.com\/authorize\?claims_locales=es&client_id=1234&login_hint=john.doe%40example.com&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}&ui_locales=en$/
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.host = 'example.com'
+        request.stubs(:params).returns('login_hint' => 'john.doe@example.com', 'ui_locales' => 'en', 'claims_locales' => 'es')
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
       def test_request_phase_with_discovery
         expected_redirect = /^https:\/\/example\.com\/authorization\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.client_options.host = 'example.com'


### PR DESCRIPTION
Hello,

These params are allowed to be used during Authentication request.
Ref: [http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)

I removed the `login_hint` option, the param has to be dynamic. I don't understand why it should be declared as an option.

Please let  me know if I misunderstood something.