### PR TITLE
Bump openid_connect dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
-before_install:
-  - gem update bundler
+language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
-  - rbx
+  - 2.4
+  - 2.5

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Originally was [omniauth-openid-connect](https://github.com/jjbohn/omniauth-open
 
 I've forked this repository and launch as separate gem because maintaining of original was dropped.
 
+[![Build Status](https://travis-ci.org/m0n9oose/omniauth_openid_connect.png?branch=master)](https://travis-ci.org/m0n9oose/omniauth_openid_connect)
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -62,7 +64,7 @@ For the full low down on OpenID Connect, please check out
 
 ## Contributing
 
-1. Fork it ( http://github.com/jjbohn/omniauth-openid-connect/fork )
+1. Fork it ( http://github.com/m0n9oose/omniauth-openid-connect/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'omniauth', '~> 1.3'
-  spec.add_dependency 'openid_connect', '~> 0.12.0'
+  spec.add_dependency 'openid_connect', '~> 1.1.0'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'minitest', '~> 5.1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'faker'
 require 'active_support'
 require 'omniauth_openid_connect'


### PR DESCRIPTION
I set the `openid_connect` dependency to a more recent version. We are using a fork of this gem with that change without any issues. I'd also setup travis, but you will need to enable it for this repo here: 
https://travis-ci.org/m0n9oose/omniauth_openid_connect

The build is passing on my fork: https://travis-ci.org/gregmolnar/omniauth_openid_connect
/cc @m0n9oose 
closes #3 