### PR TITLE
Make uid label configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea
 .yardoc
 InstalledFiles
 _yardoc

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ config.omniauth :openid_connect, {
   name: :my_provider,
   scope: [:openid, :email, :profile, :address],
   response_type: :code,
+  uid_field: "preferred_username",
   client_options: {
     port: 443,
     scheme: "https",
@@ -58,6 +59,10 @@ Configuration details:
   If provider does not have Webfinger endpoint, You can specify "Issuer" to option.  
   e.g. `issuer: "https://myprovider.com"`  
   It means to get configuration from "https://myprovider.com/.well-known/openid-configuration".
+  * The uid is by default using the `sub` value from the `user_info` response,
+  which in some applications is not the expected value. To avoid such limitations, the uid label can be
+  configured by providing the omniauth `uid_label` option to a different label (i.e. `preferred_username`)
+  that appears in the `user_info` details.
 
 For the full low down on OpenID Connect, please check out
 [the spec](http://openid.net/specs/openid-connect-core-1_0.html).

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -47,8 +47,14 @@ module OmniAuth
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
       option :post_logout_redirect_uri
+      option :uid_field, 'sub'
 
-      uid { user_info.sub }
+      def uid
+        user_info.public_send(options.uid_field.to_s)
+      rescue NoMethodError
+        log :warn, "User sub:#{user_info.sub} missing info field: #{options.uid_field}"
+        user_info.sub
+      end
 
       info do
         {

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -114,6 +114,12 @@ module OmniAuth
 
       def test_uid
         assert_equal user_info.sub, strategy.uid
+
+        strategy.options.uid_field = 'preferred_username'
+        assert_equal user_info.preferred_username, strategy.uid
+
+        strategy.options.uid_field = 'something'
+        assert_equal user_info.sub, strategy.uid
       end
 
       def test_callback_phase(session = {}, params = {})
@@ -211,6 +217,18 @@ module OmniAuth
 
         assert result.kind_of?(Array)
         assert result.first == 401, "Expecting unauthorized"
+      end
+
+      def test_callback_phase_without_code
+        state = SecureRandom.hex(16)
+        nonce = SecureRandom.hex(16)
+        request.stubs(:params).returns('state' => state)
+        request.stubs(:path_info).returns('')
+
+        strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
+
+        strategy.expects(:fail!)
+        strategy.callback_phase
       end
 
       def test_callback_phase_with_timeout


### PR DESCRIPTION
The uid is always using the `sub` value from the userinfo, which in some applications is not the expected value.

To avoid such limitations, the uid label is now configurable by providing the omniauth `uid_label` option to a different label (i.e. `preferred_username`) that appears in the userinfo details.

The default value for uid_label is set to sub to ensure the backward compatibility is not broken.