### PR TITLE
Allow state method to receive env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ For the full low down on OpenID Connect, please check out
 ## Contributing
 
 1. Fork it ( http://github.com/m0n9oose/omniauth-openid-connect/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Run the tests (`bundle install && bundle exec rake test`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -203,7 +203,9 @@ module OmniAuth
       end
 
       def new_state
-        state = options.state.call if options.state.respond_to? :call
+        if options.state.respond_to? :call
+          state = options.state.arity == 1 ? options.state.call(env) : options.state.call
+        end
         session['omniauth.state'] = state || SecureRandom.hex(16)
       end
 

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -203,9 +203,13 @@ module OmniAuth
       end
 
       def new_state
-        if options.state.respond_to? :call
-          state = options.state.arity == 1 ? options.state.call(env) : options.state.call
-        end
+        state = if options.state.respond_to?(:call)
+                  if options.state.arity == 1
+                    options.state.call(env)
+                  else
+                    options.state.call
+                  end
+                end
         session['omniauth.state'] = state || SecureRandom.hex(16)
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -329,15 +329,15 @@ module OmniAuth
       end
 
       def test_state
-        strategy.options.state = lambda { 42 }
-        session = { "state" => 42 }
+        strategy.options.state = -> { 42 }
 
-        expected_redirect = /&state=/
+        expected_redirect = /&state=42/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
 
+        session = { 'state' => 42 }
         # this should succeed as the correct state is passed with the request
         test_callback_phase(session, { 'state' => 42 })
 
@@ -351,6 +351,22 @@ module OmniAuth
 
         assert result.kind_of?(Array)
         assert result.first == 401, 'Expecting unauthorized'
+      end
+
+      def test_dynamic_state
+        # Stub request parameters
+        Strategy.send(:define_method, 'env', -> { { QUERY_STRING: { state: 'abc', client_id: '123' } } })
+
+        strategy.options.state = lambda { |env|
+          # Get params from request, e.g. CGI.parse(env['QUERY_STRING'])
+          env[:QUERY_STRING][:state] + env[:QUERY_STRING][:client_id]
+        }
+
+        expected_redirect = /&state=abc123/
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.host = 'example.com'
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
       end
 
       def test_option_client_auth_method


### PR DESCRIPTION
I have a state algorithm that requires access to values in env. This change allows it to receive that reference in a backwards compatible way and brings the state method in line with the setup method.