### PR TITLE
Update openid-connect to 1.0.3

### DIFF
--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '~> 0.9.2'
+  spec.add_dependency 'openid_connect', '~> 1.0', '>= 1.0.3'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
This gets rid of `DEPRECATION WARNING: alias_method_chain is
deprecated. Please, use Module#prepend instead. From module, you can
access the original method using super.`