### PR TITLE
Add OIDC claims parameter support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ Metrics/MethodLength:
   Max: 45
 
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - bin/**/*
     - Rakefile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Layout/MultilineOperationIndentation:
 StringLiterals:
   EnforcedStyle: single_quotes
 
+Style/CaseEquality:
+  Enabled: false
+
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInHashLiteral:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.4.0 (5.06.2019)
+
+- Add claims parameter to authorize request
+- Allow options to be modified both by options and by request parameters, prioritizing request parameters
+- Support back to Ruby 2.3
+- Make it clear what options come from what standards
+
 # v0.3.1 (08.06.2019)
 
 - Set default OmniAuth name to openid_connect [#23](https://github.com/m0n9oose/omniauth_openid_connect/pull/23)

--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.3.1'
+    VERSION = '0.4.0'
   end
 end

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.files         = `git ls-files -z`.split("\x0")
   spec.homepage      = 'https://github.com/m0n9oose/omniauth_openid_connect'
-  spec.license       = ['MIT']
+  spec.license       = 'MIT'
   spec.name          = 'omniauth_openid_connect'
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3'

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'omniauth', '~> 1.3'
   spec.add_dependency 'openid_connect', '~> 1.1'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'coveralls', '~> 0.8'ZZz
   spec.add_development_dependency 'faker', '~> 1.6'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.2'
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.files         = `git ls-files -z`.split("\x0")
   spec.homepage      = 'https://github.com/m0n9oose/omniauth_openid_connect'
-  spec.license       = %w[MIT]
+  spec.license       = ['MIT']
   spec.name          = 'omniauth_openid_connect'
-  spec.require_paths = %w[lib]
+  spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3'
   spec.summary       = spec.description
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'omniauth', '~> 1.3'
   spec.add_dependency 'openid_connect', '~> 1.1'
-  spec.add_development_dependency 'coveralls', '~> 0.8'ZZz
+  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'faker', '~> 1.6'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.2'

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -5,20 +5,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/openid_connect/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'omniauth_openid_connect'
-  spec.version       = OmniAuth::OpenIDConnect::VERSION
-  spec.authors       = ['John Bohn', 'Ilya Shcherbinin']
-  spec.email         = ['jjbohn@gmail.com', 'm0n9oose@gmail.com']
-  spec.summary       = 'OpenID Connect Strategy for OmniAuth'
-  spec.description   = 'OpenID Connect Strategy for OmniAuth.'
-  spec.homepage      = 'https://github.com/jjbohn/omniauth-openid-connect'
-  spec.license       = 'MIT'
-
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
-
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'omniauth', '~> 1.3'
   spec.add_dependency 'openid_connect', '~> 1.1'
@@ -32,4 +18,17 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.63'
   spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.authors       = ['John Bohn', 'Ilya Shcherbinin']
+  spec.description   = 'OpenID Connect Strategy for OmniAuth.'
+  spec.email         = ['jjbohn@gmail.com', 'm0n9oose@gmail.com']
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.homepage      = 'https://github.com/m0n9oose/omniauth_openid_connect'
+  spec.license       = %w[MIT]
+  spec.name          = 'omniauth_openid_connect'
+  spec.require_paths = %w[lib]
+  spec.required_ruby_version = '>= 2.3'
+  spec.summary       = spec.description
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.version       = OmniAuth::OpenIDConnect::VERSION
 end


### PR DESCRIPTION
# In progress PR. Working on a fork for now: https://github.com/teespring/omniauth_openid_connect/pull/1

---

## What
This ruby gem allows us to authenticate with OpenID Connect providers through omniauth. Upstream it doesn't currently support the [`claims` parameter](https://openid.net/specs/openid-connect-core-1_0.html#Claims) (which is optional in the OpenID standard).

## Changes
- Add claims parameter to authorize request
- Allow options to be modified both by options and by request parameters, prioritizing request parameters
- Support back to Ruby 2.3
- Make it clear what options come from what standards