### PR TITLE
Set default OmniAuth name to openid_connect

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -16,6 +16,7 @@ module OmniAuth
 
       def_delegator :request, :params
 
+      option :name, 'openid_connect'
       option(:client_options, identifier: nil,
                               secret: nil,
                               redirect_uri: nil,

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -35,7 +35,7 @@ module OmniAuth
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
-        request.stubs(:path_info).returns('/auth/openidconnect/logout')
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.other_phase
@@ -59,7 +59,7 @@ module OmniAuth
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
-        request.stubs(:path_info).returns('/auth/openidconnect/logout')
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(expected_redirect)
         strategy.other_phase
@@ -69,7 +69,7 @@ module OmniAuth
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
 
-        request.stubs(:path_info).returns('/auth/openidconnect/logout')
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
         strategy.expects(:call_app!)
         strategy.other_phase


### PR DESCRIPTION
If no name option is given, OmniAuth will attempt to translate
`OmniAuth::Strategies::OpenIDConnect` to `openidconnect`. This led
to confusion for a number of GitLab users who omitted the name
argument because `/users/auth/openid_connect` did not match
`/users/auth/openidconnect`.