### PR TITLE
Use response_mode in authorize_uri if the option is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Configuration details:
   configured by providing the omniauth `uid_field` option to a different label (i.e. `preferred_username`)
   that appears in the `user_info` details.
   * The `issuer` property should exactly match the provider's issuer link.
+  * The `response_mode` option is optional and specifies how the result of the authorization request is formatted.
 
 For the full low down on OpenID Connect, please check out
 [the spec](http://openid.net/specs/openid-connect-core-1_0.html).

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -37,7 +37,7 @@ module OmniAuth
       option :scope, [:openid]
       option :response_type, 'code'
       option :state
-      option :response_mode
+      option :response_mode # [:query, :fragment, :form_post, :web_message]
       option :display, nil # [:page, :popup, :touch, :wap]
       option :prompt, nil # [:none, :login, :consent, :select_account]
       option :hd, nil
@@ -150,6 +150,7 @@ module OmniAuth
         client.redirect_uri = redirect_uri
         opts = {
           response_type: options.response_type,
+          response_mode: options.response_mode,
           scope: options.scope,
           state: new_state,
           login_hint: params['login_hint'],

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -112,6 +112,17 @@ module OmniAuth
         assert_nil strategy.options.client_options.end_session_endpoint
       end
 
+      def test_request_phase_with_response_mode
+        expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=\w{32}&response_mode=form_post&response_type=id_token&scope=openid&state=\w{32}$/
+        strategy.options.issuer = 'example.com'
+        strategy.options.response_mode = 'form_post'
+        strategy.options.response_type = 'id_token'
+        strategy.options.client_options.host = 'example.com'
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
       def test_uid
         assert_equal user_info.sub, strategy.uid
 


### PR DESCRIPTION
This resolves: https://github.com/m0n9oose/omniauth_openid_connect/issues/29

Some OpenID servers are configured to format the request to the client application as a POST request (form_post). This PR allows you to actually use an unused configuration option.