### PR TITLE
Add support for response_type id_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Configuration details:
   **NOTE**: if you use this gem with Devise you should use `:openid_connect` name,
   or Devise would route to 'users/auth/:provider' rather than 'users/auth/openid_connect'
 
-  * Although `response_type` is an available option, currently, only `:code`
-  is valid. There are plans to bring in implicit flow and hybrid flow at some
-  point, but it hasn't come up yet for me. Those flows aren't best practive for
-  server side web apps anyway and are designed more for native/mobile apps.
-  * If you want to pass `state` paramete by yourself. You can set Proc Object.  
+  * `response_type` tells the authorization server which grant type the application wants to use,
+  currently, only `:code` (Authorization Code grant) and `:id_token` (Implicit grant) are valid.
+  There are plans to bring in hybrid flow at some point, but it hasn't come up yet for us.
+  Those flows aren't best practive for server side web apps anyway and are designed more for native/mobile apps.
+  * If you want to pass `state` paramete by yourself. You can set Proc Object.
   e.g. `state: Proc.new { SecureRandom.hex(32) }`
   * `nonce` is optional. If don't want to pass "nonce" parameter to provider, You should specify
   `false` to `send_nonce` option. (default true)
@@ -60,8 +60,8 @@ Configuration details:
   `:client_auth_method` option, automatically set `:basic`.
   * Use "OpenID Connect Discovery", You should specify `true` to `discovery` option. (default false)
   * In "OpenID Connect Discovery", generally provider should have Webfinger endpoint.
-  If provider does not have Webfinger endpoint, You can specify "Issuer" to option.  
-  e.g. `issuer: "https://myprovider.com"`  
+  If provider does not have Webfinger endpoint, You can specify "Issuer" to option.
+  e.g. `issuer: "https://myprovider.com"`
   It means to get configuration from "https://myprovider.com/.well-known/openid-configuration".
   * The uid is by default using the `sub` value from the `user_info` response,
   which in some applications is not the expected value. To avoid such limitations, the uid label can be

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Configuration details:
 
   * `response_type` tells the authorization server which grant type the application wants to use,
   currently, only `:code` (Authorization Code grant) and `:id_token` (Implicit grant) are valid.
-  There are plans to bring in hybrid flow at some point, but it hasn't come up yet for us.
-  Those flows aren't best practive for server side web apps anyway and are designed more for native/mobile apps.
   * If you want to pass `state` paramete by yourself. You can set Proc Object.
   e.g. `state: Proc.new { SecureRandom.hex(32) }`
   * `nonce` is optional. If don't want to pass "nonce" parameter to provider, You should specify

--- a/lib/omniauth/openid_connect/errors.rb
+++ b/lib/omniauth/openid_connect/errors.rb
@@ -4,5 +4,6 @@ module OmniAuth
   module OpenIDConnect
     class Error < RuntimeError; end
     class MissingCodeError < Error; end
+    class MissingIdTokenError < Error; end
   end
 end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -237,7 +237,20 @@ module OmniAuth
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
-        strategy.expects(:fail!)
+        strategy.expects(:fail!).with(:missing_code, is_a(OmniAuth::OpenIDConnect::MissingCodeError))
+        strategy.callback_phase
+      end
+
+      def test_callback_phase_without_id_token
+        state = SecureRandom.hex(16)
+        nonce = SecureRandom.hex(16)
+        request.stubs(:params).returns('state' => state)
+        request.stubs(:path_info).returns('')
+        strategy.options.response_type = 'id_token'
+
+        strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
+
+        strategy.expects(:fail!).with(:missing_id_token, is_a(OmniAuth::OpenIDConnect::MissingIdTokenError))
         strategy.callback_phase
       end
 


### PR DESCRIPTION
Current implementation will always trigger the `failure` action in the client for the Implicit grant. It's because we call `Omniauth::Strategy` `.fail!` method if parameter `code` is missing.

Resolves: https://github.com/m0n9oose/omniauth_openid_connect/issues/31

For the Implicit grant, the `id_token` or both `id_token` and `access_token` may be returned.
NOTICE: when `response_type` is set to `token`, then `access_token` parameter is used (Bearer token).

A much simpler implementation to handle just the 2 cases, `code` or `id_token` could look like:

```ruby
def callback_phase
  # ...
  return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(params['error'])) unless valid_code?
  return fail!(:missing_id_token, OmniAuth::OpenIDConnect::MissingIdTokenError.new(params['error'])) unless valid_id_token?
  # ...
end

def valid_code?
  options.response_type == 'code' ? params.key?('code') : true
end
def valid_id_token?
  options.response_type == 'id_token' ? params.key('id_token') : true
end
```

Let me know which option would you prefer to start with
