### PR TITLE
Verify id_token when present in response_type

### DIFF
--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -155,11 +155,6 @@ module OmniAuth
         strategy.options.client_signing_alg = :RS256
         strategy.options.client_jwk_signing_key = File.read('test/fixtures/jwks.json')
 
-        id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-        id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)
-        ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
-        id_token.expects(:verify!)
-
         strategy.unstub(:user_info)
         access_token = stub('OpenIDConnect::AccessToken')
         access_token.stubs(:access_token)


### PR DESCRIPTION
It verifies `id_token` only when `id_token` is present in `options.response_type`.

It fixes the problem from #28.