### PR TITLE
Support both symbol and string version of response_type option

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -315,7 +315,7 @@ module OmniAuth
       def valid_response_type?
         return true if params.key?(options.response_type)
 
-        error_attrs = RESPONSE_TYPE_EXCEPTIONS[options.response_type]
+        error_attrs = RESPONSE_TYPE_EXCEPTIONS[options.response_type.to_s]
         fail!(error_attrs[:key], error_attrs[:exception_class].new(params['error']))
 
         false


### PR DESCRIPTION
Apparently it never worked as a symbol, although it was mentioned in the README before.

A change that revealed it was introduced in: https://github.com/m0n9oose/omniauth_openid_connect/pull/32

With this PR, both string and symbol versions are supported. Another option is to stick to one: either string or symbol and adjust the lib and test accordingly.