### PR TITLE
Cast response_type to string when checking if it is set in params

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -313,7 +313,7 @@ module OmniAuth
       end
 
       def valid_response_type?
-        return true if params.key?(options.response_type)
+        return true if params.key?(options.response_type.to_s)
 
         error_attrs = RESPONSE_TYPE_EXCEPTIONS[options.response_type.to_s]
         fail!(error_attrs[:key], error_attrs[:exception_class].new(params['error']))

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -126,7 +126,7 @@ module OmniAuth
         discover!
         client.redirect_uri = redirect_uri
 
-        return id_token_callback_phase if options.response_type.to_s == 'id_token'
+        return id_token_callback_phase if configured_response_type == 'id_token'
 
         client.authorization_code = authorization_code
         access_token
@@ -313,12 +313,16 @@ module OmniAuth
       end
 
       def valid_response_type?
-        return true if params.key?(options.response_type.to_s)
+        return true if params.key?(configured_response_type)
 
-        error_attrs = RESPONSE_TYPE_EXCEPTIONS[options.response_type.to_s]
+        error_attrs = RESPONSE_TYPE_EXCEPTIONS[configured_response_type]
         fail!(error_attrs[:key], error_attrs[:exception_class].new(params['error']))
 
         false
+      end
+
+      def configured_response_type
+        @configured_response_type ||= options.response_type.to_s
       end
 
       class CallbackError < StandardError

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -154,6 +154,7 @@ module OmniAuth
         strategy.options.issuer = 'example.com'
         strategy.options.client_signing_alg = :RS256
         strategy.options.client_jwk_signing_key = File.read('test/fixtures/jwks.json')
+        strategy.options.response_type = :code
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
         id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)


### PR DESCRIPTION
Rails will provide params with indifferent access but that's not guaranteed with other frameworks.
Actually the automated test suite provides params object as a regular `Hash`

Omniauth sets keys as string, e.g. hash[field] = request.params[field.to_s] for the Developer strategy.

Adding `strategy.options.response_type = :code` alone to the `test_callback_phase` test is enough to trigger an error.