### PR TITLE
Add raw_info to auth_hash for response_type id_token

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -109,9 +109,8 @@ module OmniAuth
         error = params['error_reason'] || params['error']
         error_description = params['error_description'] || params['error_reason']
         invalid_state = params['state'].to_s.empty? || params['state'] != stored_state
-
+        
         raise CallbackError.new(params['error'], error_description, params['error_uri']) if error
-
         raise CallbackError, 'Invalid state parameter' if invalid_state
 
         return unless valid_response_type?
@@ -126,7 +125,7 @@ module OmniAuth
         discover!
         client.redirect_uri = redirect_uri
 
-        return id_token_callback_phase if options.response_type.to_s == 'id_token'
+        return id_token_callback_phase if configured_response_type == 'id_token'
 
         client.authorization_code = authorization_code
         access_token
@@ -251,6 +250,13 @@ module OmniAuth
         super
       end
 
+      def env
+        reply = super
+        return reply unless reply.nil?
+
+        @env ||= {}
+      end
+
       def key_or_secret
         case options.client_signing_alg
         when :HS256, :HS384, :HS512
@@ -307,18 +313,23 @@ module OmniAuth
         env['omniauth.auth'] = AuthHash.new(
           provider: name,
           uid: user_data['sub'],
-          info: { name: user_data['name'], email: user_data['email'] }
+          info: { name: user_data['name'], email: user_data['email'] },
+          extra: {raw_info: user_data}
         )
         call_app!
       end
 
       def valid_response_type?
-        return true if params.key?(options.response_type)
+        return true if params.key?(configured_response_type)
 
-        error_attrs = RESPONSE_TYPE_EXCEPTIONS[options.response_type.to_s]
+        error_attrs = RESPONSE_TYPE_EXCEPTIONS[configured_response_type]
         fail!(error_attrs[:key], error_attrs[:exception_class].new(params['error']))
 
         false
+      end
+
+      def configured_response_type
+        @configured_response_type ||= options.response_type.to_s
       end
 
       class CallbackError < StandardError


### PR DESCRIPTION
Adds the key extra with raw_info to the auth_hash returned to the controller in the callback_phase for response type id_token instead of stripping away most of the information returned from the server. The structure of the authorization hash is the same as for response_type code with regards to the extra and raw_info.