### PR TITLE
Pass acr_values to authorize url

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -172,6 +172,7 @@ module OmniAuth
           prompt: options.prompt,
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
+          acr_values: options.acr_values,
         }
         client.authorization_uri(opts.reject { |_k, v| v.nil? })
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -134,6 +134,15 @@ module OmniAuth
         strategy.request_phase
       end
 
+      def test_option_acr_values
+        strategy.options.client_options[:host] = 'foobar.com'
+
+        assert(!(strategy.authorize_uri =~ /acr_values=/), 'URI must not contain acr_values')
+
+        strategy.options.acr_values = 'urn:some:acr:values:value'
+        assert(strategy.authorize_uri =~ /acr_values=/, 'URI must contain acr_values')
+      end
+
       def test_uid
         assert_equal user_info.sub, strategy.uid
 


### PR DESCRIPTION
Currently there is an option defined for `acr_values`, but it is not passed to the authorize url.

This small PR fixes that, it's based on an open PR on the repo's parent: https://github.com/jjbohn/omniauth-openid-connect/pull/53/files