### PR TITLE
Use !!match rather than match? for Regexp in Rubies before 2.4

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -135,7 +135,7 @@ module OmniAuth
       end
 
       def other_phase
-        if logout_path_pattern.match?(current_path)
+        if !!logout_path_pattern.match(current_path)
           options.issuer = issuer if options.issuer.to_s.empty?
           discover!
           return redirect(end_session_uri) if end_session_uri


### PR DESCRIPTION
`Regexp#match?` was introduced in ruby 2.4; this change will maintain compatibility with older rubies like 2.3.