### PR TITLE
Support custom paramters to the authorize URI

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -54,6 +54,7 @@ module OmniAuth
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
       option :post_logout_redirect_uri
+      option :extra_authorize_params, {}
       option :uid_field, 'sub'
 
       def uid
@@ -170,6 +171,11 @@ module OmniAuth
           hd: options.hd,
           acr_values: options.acr_values,
         }
+
+        unless options.extra_authorize_params.empty?
+          opts.merge!(options.extra_authorize_params)
+        end
+
         client.authorization_uri(opts.reject { |_k, v| v.nil? })
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -143,6 +143,13 @@ module OmniAuth
         assert(strategy.authorize_uri =~ /acr_values=/, 'URI must contain acr_values')
       end
 
+      def test_option_custom_attributes
+        strategy.options.client_options[:host] = 'foobar.com'
+        strategy.options.extra_authorize_params = {resource: 'xyz'}
+
+        assert(strategy.authorize_uri =~ /resource=xyz/, 'URI must contain custom params')
+      end
+
       def test_uid
         assert_equal user_info.sub, strategy.uid
 


### PR DESCRIPTION
Some OIDC providers allow extra paramters, not convered by the default configuration
we pass through.

An example of this is Azure AD, which adds the `resource` parameter which is used to
scope access of the resultant access token.

This adds the ability to pass through custom attributes, as a catch all, to the authorize URI.