### PR TITLE
refactor: take uid_field from raw_attributes

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -58,10 +58,7 @@ module OmniAuth
       option :uid_field, 'sub'
 
       def uid
-        user_info.public_send(options.uid_field.to_s)
-      rescue NoMethodError
-        log :warn, "User sub:#{user_info.sub} missing info field: #{options.uid_field}"
-        user_info.sub
+        user_info.raw_attributes[options.uid_field.to_sym] || user_info.sub
       end
 
       info do


### PR DESCRIPTION
In some cases a non standard uid_field is required, so instead of adding a lot of extra logic just select the field from `user_info.raw_attributes` with `user_info.sub` as fallback makes this corner case work as well.