### PR TITLE
bugfix: NoMethodError (undefined method `count' for #<OpenIDConnect::ResponseObject::IdToken>):

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -212,7 +212,7 @@ module OmniAuth
           client_auth_method: options.client_auth_method
         )
 
-        verify_id_token!(decode_id_token(@access_token.id_token)) if configured_response_type == 'code'
+        verify_id_token!(@access_token.id_token) if configured_response_type == 'code'
 
         @access_token
       end
@@ -330,6 +330,8 @@ module OmniAuth
       end
 
       def verify_id_token!(id_token)
+        return unless id_token
+
         decode_id_token(id_token).verify!(issuer: options.issuer,
                                           client_id: client_options.identifier,
                                           nonce: stored_nonce)

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -185,9 +185,9 @@ module OmniAuth
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
         id_token.stubs(:raw_attributes).returns('sub' => 'sub', 'name' => 'name', 'email' => 'email')
         id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)
-        ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
         id_token.expects(:verify!)
 
+        strategy.expects(:decode_id_token).with(access_token.id_token).returns(id_token)
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
         strategy.callback_phase
       end


### PR DESCRIPTION
since id_token gets decoded twice

fix #59 