### PR TITLE
bugfix: info from decoded id_token is not exposed into `request.env['omniauth.auth']`

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -201,7 +201,15 @@ module OmniAuth
       end
 
       def user_info
-        @user_info ||= access_token.userinfo!
+        return @user_info if @user_info
+
+        if access_token.id_token
+          decoded = decode_id_token(access_token.id_token).raw_attributes
+
+          @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new access_token.userinfo!.raw_attributes.merge(decoded)
+        else
+          @user_info = access_token.userinfo!
+        end
       end
 
       def access_token

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -187,7 +187,7 @@ module OmniAuth
         id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)
         id_token.expects(:verify!)
 
-        strategy.expects(:decode_id_token).with(access_token.id_token).returns(id_token)
+        strategy.expects(:decode_id_token).twice.with(access_token.id_token).returns(id_token)
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
         strategy.callback_phase
       end
@@ -248,6 +248,7 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
+        id_token.stubs(:raw_attributes).returns('sub' => 'sub', 'name' => 'name', 'email' => 'email')
         id_token.stubs(:verify!).with(issuer: 'https://example.com/', client_id: @identifier, nonce: nonce).returns(true)
         ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
 
@@ -587,7 +588,7 @@ module OmniAuth
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
         id_token.stubs(:verify!).returns(true)
-        id_token.stubs(:raw_attributes, :to_h).returns( 
+        id_token.stubs(:raw_attributes, :to_h).returns(
           {
             "iss": "http://server.example.com",
             "sub": "248289761001",


### PR DESCRIPTION
the issue happens when `response_type: code` is used together with `scope: openid`.. `callback_phase` will ignore `access_token.id_token` and include only information from the `access_token` itself..

this is problematic under azure active directory, since in some installation, `user_info.email` will be `nil` even though the value exists inside `id_token`..