### PR TITLE
solved KidNotFound error during signature verification

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -226,7 +226,7 @@ module OmniAuth
       end
 
       def decode_id_token(id_token)
-        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, :skip_verification)
+        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, public_key[0])
       end
 
       def client_options

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -226,7 +226,7 @@ module OmniAuth
       end
 
       def decode_id_token(id_token)
-        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, public_key)
+        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, :skip_verification)
       end
 
       def client_options


### PR DESCRIPTION
This is a temporary fix. We will reintroduce signature verification without kid later.