### PR TITLE
Add `issuer:` arg to quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Example configuration
 ```ruby
 config.omniauth :openid_connect, {
   name: :my_provider,
+  issuer: 'https://myprovider.com',
   scope: [:openid, :email, :profile, :address],
   response_type: :code,
   uid_field: "preferred_username",


### PR DESCRIPTION
We weren't able to get the example to work until we added the `issuer` -- in the table describing options, it is marked as required, but is not in the example.

Issuer https://github.com/m0n9oose/omniauth_openid_connect/issues/18#issuecomment-483508101