### PR TITLE
Upgrade omniauth to 2.0

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -10,6 +10,7 @@ require 'forwardable'
 
 module OmniAuth
   module Strategies
+    # rubocop:disable Metrics/ClassLength
     class OpenIDConnect
       include OmniAuth::Strategy
       extend Forwardable
@@ -103,6 +104,7 @@ module OmniAuth
         redirect authorize_uri
       end
 
+      # rubocop:disable Metrics/AbcSize
       def callback_phase
         error = params['error_reason'] || params['error']
         error_description = params['error_description'] || params['error_reason']
@@ -133,6 +135,7 @@ module OmniAuth
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)
       end
+      # rubocop:enable Metrics/AbcSize
 
       def other_phase
         if logout_path_pattern.match?(current_path)
@@ -359,6 +362,7 @@ module OmniAuth
         end
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end
 

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -5,23 +5,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/openid_connect/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'omniauth_openid_connect'
-  spec.version       = OmniAuth::OpenIDConnect::VERSION
-  spec.authors       = ['John Bohn', 'Ilya Shcherbinin']
-  spec.email         = ['jjbohn@gmail.com', 'm0n9oose@gmail.com']
-  spec.summary       = 'OpenID Connect Strategy for OmniAuth'
-  spec.description   = 'OpenID Connect Strategy for OmniAuth.'
-  spec.homepage      = 'https://github.com/m0n9oose/omniauth_openid_connect'
-  spec.license       = 'MIT'
+  spec.name                   = 'omniauth_openid_connect'
+  spec.version                = OmniAuth::OpenIDConnect::VERSION
+  spec.authors                = ['John Bohn', 'Ilya Shcherbinin']
+  spec.email                  = ['jjbohn@gmail.com', 'm0n9oose@gmail.com']
+  spec.summary                = 'OpenID Connect Strategy for OmniAuth'
+  spec.description            = 'OpenID Connect Strategy for OmniAuth.'
+  spec.homepage               = 'https://github.com/m0n9oose/omniauth_openid_connect'
+  spec.license                = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.files                  = `git ls-files -z`.split("\x0")
+  spec.executables            = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files             = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths          = ['lib']
+  spec.required_ruby_version  = '>= 2.4'
 
   spec.add_dependency 'addressable', '~> 2.5'
-  spec.add_dependency 'omniauth', '~> 1.9'
-  spec.add_dependency 'openid_connect', '~> 1.1'
+  spec.add_dependency 'omniauth', '~> 2.0'
+  spec.add_dependency 'openid_connect', '~> 1.2'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'faker', '~> 1.6'
   spec.add_development_dependency 'guard', '~> 2.14'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -22,6 +22,7 @@ module OmniAuth
         expected_redirect = %r{^https:\/\/example\.com\/logout$}
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
+        strategy.stubs(:script_name).returns('')
 
         issuer = stub('OpenIDConnect::Discovery::Issuer')
         issuer.stubs(:issuer).returns('https://example.com/')
@@ -46,6 +47,7 @@ module OmniAuth
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
         strategy.options.post_logout_redirect_uri = 'https://mysite.com'
+        strategy.stubs(:script_name).returns('')
 
         issuer = stub('OpenIDConnect::Discovery::Issuer')
         issuer.stubs(:issuer).returns('https://example.com/')
@@ -68,6 +70,7 @@ module OmniAuth
       def test_logout_phase
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
+        strategy.stubs(:script_name).returns('')
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
@@ -166,6 +169,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
         strategy.options.client_signing_alg = :RS256
@@ -198,6 +202,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('id_token' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
         strategy.options.client_signing_alg = :RS256
@@ -230,6 +235,7 @@ module OmniAuth
 
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
@@ -271,6 +277,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('error' => 'invalid_request')
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!({'rack.session' => {'omniauth.state' => state, 'omniauth.nonce' => nonce}})
         strategy.expects(:fail!)
@@ -283,6 +290,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => 'foobar')
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
         strategy.expects(:fail!)
@@ -294,6 +302,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
@@ -306,6 +315,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.options.response_type = 'id_token'
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
@@ -319,6 +329,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.options.response_type = :id_token
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
@@ -333,6 +344,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -353,6 +365,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -373,6 +386,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -393,6 +407,7 @@ module OmniAuth
         nonce = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => state)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.options.issuer = 'example.com'
 
@@ -494,6 +509,7 @@ module OmniAuth
         code = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => 43)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.call!('rack.session' => session)
         strategy.expects(:fail!)
@@ -503,6 +519,7 @@ module OmniAuth
       def test_dynamic_state
         # Stub request parameters
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.call!('rack.session' => { }, QUERY_STRING: { state: 'abc', client_id: '123' } )
 
         strategy.options.state = lambda { |env|
@@ -536,6 +553,7 @@ module OmniAuth
         success = Struct.new(:status, :body).new(200, json_response)
 
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
@@ -601,6 +619,7 @@ module OmniAuth
 
         request.stubs(:params).returns('state' => state, 'nounce' => nonce, 'id_token' => id_token)
         request.stubs(:path_info).returns('')
+        request.stubs(:path).returns('')
 
         strategy.stubs(:decode_id_token).returns(id_token)
         strategy.stubs(:stored_state).returns(state)


### PR DESCRIPTION
Because I was getting the CVE-2015-9284 because the version of omniauth was too low, I've upgraded it to a newer version.

This should fix #81.

The only change I also had to add was the following, to have the `GET /auth/:provider` to work

```ruby
OmniAuth.config.allowed_request_methods = [:get, :post]
```