### PR TITLE
Allow to update omniauth to 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 LineLength:
   Description: 'Limit lines to 130 characters.'
   Max: 130
@@ -36,7 +39,10 @@ Documentation:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 50
+  Max: 60
+
+Metrics/ClassLength:
+  Max: 300
 
 Metrics/CyclomaticComplexity:
   Max: 50

--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@
 
 guard 'minitest' do
   # with Minitest::Unit
-  watch(%r{^test/(.*)\/(.*)_test\.rb})
+  watch(%r{^test/(.*)/(.*)_test\.rb})
   watch(%r{^lib/(.*)\.rb}) { |m| "test/lib/#{m[1]}_test.rb" }
   watch(%r{^test/test_helper\.rb}) { 'test' }
 end

--- a/lib/omniauth/openid_connect/errors.rb
+++ b/lib/omniauth/openid_connect/errors.rb
@@ -3,7 +3,9 @@
 module OmniAuth
   module OpenIDConnect
     class Error < RuntimeError; end
+
     class MissingCodeError < Error; end
+
     class MissingIdTokenError < Error; end
   end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -349,6 +349,7 @@ module OmniAuth
         attr_accessor :error, :error_reason, :error_uri
 
         def initialize(data)
+          super
           self.error = data[:error]
           self.error_reason = data[:reason]
           self.error_uri = data[:uri]

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.1'
   spec.add_development_dependency 'mocha', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.63'
+  spec.add_development_dependency 'rubocop', '~> 1.12'
   spec.add_development_dependency 'simplecov', '~> 0.12'
 end

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'addressable', '~> 2.5'
-  spec.add_dependency 'omniauth', '~> 1.9'
+  spec.add_dependency 'omniauth', '>= 1.9', '< 3'
   spec.add_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'faker', '~> 1.6'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -36,6 +36,7 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.other_phase
@@ -60,6 +61,7 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(expected_redirect)
         strategy.other_phase

--- a/test/strategy_test_case.rb
+++ b/test/strategy_test_case.rb
@@ -37,6 +37,7 @@ class StrategyTestCase < MiniTest::Test
       request.stubs(:env).returns({})
       request.stubs(:scheme).returns({})
       request.stubs(:ssl?).returns(false)
+      request.stubs(:path).returns('')
     end
   end
 
@@ -46,6 +47,7 @@ class StrategyTestCase < MiniTest::Test
       strategy.options.client_options.secret = @secret
       strategy.stubs(:request).returns(request)
       strategy.stubs(:user_info).returns(user_info)
+      strategy.stubs(:script_name).returns('')
     end
   end
 end


### PR DESCRIPTION
This PR is to allow users of this gem to update omniauth to version 2 (security fix).
I have also made some adjustments to make rubocop pass.