### PR TITLE
Always convert client_signing_alg to be a symbol

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -263,7 +263,7 @@ module OmniAuth
       end
 
       def key_or_secret
-        case options.client_signing_alg
+        case options.client_signing_alg&.to_sym
         when :HS256, :HS384, :HS512
           client_options.secret
         when :RS256, :RS384, :RS512


### PR DESCRIPTION
client_singing_alg could be passed in as a string, and we should make it
possible to specify either a string or symbol.