### PR TITLE
Allow cache options to be set for Config discovery

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -36,6 +36,7 @@ module OmniAuth
 
       option :issuer
       option :discovery, false
+      option :discovery_cache_options, {}
       option :client_signing_alg
       option :client_jwk_signing_key
       option :client_x509_signing_key
@@ -94,7 +95,7 @@ module OmniAuth
       end
 
       def config
-        @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer)
+        @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer, options.discovery_cache_options)
       end
 
       def request_phase

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -33,7 +33,7 @@ module OmniAuth
         config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
         config.stubs(:jwks_uri).returns('https://example.com/jwks')
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
-        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', {}).returns(config)
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
@@ -57,7 +57,7 @@ module OmniAuth
         config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
         config.stubs(:jwks_uri).returns('https://example.com/jwks')
         config.stubs(:end_session_endpoint).returns('https://example.com/logout')
-        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', {}).returns(config)
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
@@ -89,6 +89,7 @@ module OmniAuth
         expected_redirect = /^https:\/\/example\.com\/authorization\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
+        strategy.options.discovery_cache_options = { expires_in: 1.hour }
 
         issuer = stub('OpenIDConnect::Discovery::Issuer')
         issuer.stubs(:issuer).returns('https://example.com/')
@@ -99,7 +100,7 @@ module OmniAuth
         config.stubs(:token_endpoint).returns('https://example.com/token')
         config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
         config.stubs(:jwks_uri).returns('https://example.com/jwks')
-        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', strategy.options.discovery_cache_options).returns(config)
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
@@ -245,7 +246,7 @@ module OmniAuth
         config.stubs(:jwks_uri).returns('https://example.com/jwks')
         config.stubs(:jwks).returns(jwks)
 
-        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/', {}).returns(config)
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
         id_token.stubs(:raw_attributes).returns('sub' => 'sub', 'name' => 'name', 'email' => 'email')


### PR DESCRIPTION
Hiya - first up, thanks for maintaining this gem!

One feature of the `openid_connect` gem is passing cache options to caching of the discovery responses.

Where I work we'd like to use that feature so that:
* our client applications don't completely start to fail in the event our IdP goes down
* we keep traffic between our services down
* we improve request latency to our client applications (for endpoints which require the use of other services)

But we want the cache to expire, so we can reconfigure the IdP and not have to redeploy our client applications.

Since this is already largely supported by openid_connect, all it took was adding `discovery_cache_options` as an option to the strategy, defaulting to {}, which is directly passed to OpenIDConnect::Discovery::Provider::Config.discover!

In the specs I used a mixture of the default behaviour and providing a hash of cache options - to ensure thorough coverage.

I've been 

Thanks in advance for taking a look!