### PR TITLE
Fall back to the discovered jwks when no key specified

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -179,7 +179,7 @@ module OmniAuth
       def public_key
         return config.jwks if options.discovery
 
-        key_or_secret
+        key_or_secret || config.jwks
       end
 
       private


### PR DESCRIPTION
When no key has been explicitly specified, `key_or_secret` may return an empty value, leading to a token decoding error, when discovery is disabled:
```
JSON::JWS::VerificationFailed (JSON::JWS::VerificationFailed):
  /usr/lib/ruby/vendor_ruby/json/jws.rb:26:in `verify!'
  /usr/lib/ruby/vendor_ruby/json/jws.rb:149:in `decode_compact_serialized'
  /usr/lib/ruby/vendor_ruby/json/jwt.rb:86:in `decode_compact_serialized'
  /usr/lib/ruby/vendor_ruby/json/jose.rb:52:in `decode'
  ...
```

The actual discovery is performed in any case (but the discovered values aren’t used), so why not use that key if nothing else is available.